### PR TITLE
Split permissions and add host_permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,9 @@
     }
   ],
   "permissions": [
-    "activeTab",
+    "activeTab"
+  ],
+  "host_permissions": [
     "https://api.openai.com/*"
   ],
   "web_accessible_resources": [
@@ -21,5 +23,4 @@
       "matches": ["<all_urls>"]
     }
   ]
-  
 }


### PR DESCRIPTION
On my machine (Ubuntu 22.04, Chrome 111.0.5563.64)  the extension generated:
'Permission 'https://api.openai.com/*' is unknown or URL pattern is malformed.'